### PR TITLE
maintain entity fields so they are easily accessible through godot

### DIFF
--- a/addons/qodot/src/build/step/build_nodes/build_entity_spawns.gd
+++ b/addons/qodot/src/build/step/build_nodes/build_entity_spawns.gd
@@ -86,7 +86,8 @@ func _run(context) -> Dictionary:
 				'trigger':
 					node = null
 				_:
-					node = Position3D.new()
+					node = QodotEntity.new()
+					node.properties = entity_properties
 					if 'angle' in entity_properties:
 						node.rotation.y = deg2rad(180 + entity_properties['angle'])
 


### PR DESCRIPTION
Unsure how this would work with gdscript, but it allows anonymous access to the fields from the .map file instead of discarding it when using c#:

` 
Spatial entitySpawns = GetNode("/root/Path/To/QodotMap/Entity Spawns") as Spatial;
        Godot.Collections.Array ents = entitySpawns.GetChildren();
        foreach(Spatial ent in ents)
        {
            Godot.Collections.Dictionary fields = ent.Get("properties") as Godot.Collections.Dictionary;
        }
`