### PR TITLE
Fix fgd file name in example maps to show entities in trenchbroom

### DIFF
--- a/addons/qodot/example_scenes/0-visuals/5-baked-lighting/5-baked-lighting.map
+++ b/addons/qodot/example_scenes/0-visuals/5-baked-lighting/5-baked-lighting.map
@@ -3,7 +3,7 @@
 // entity 0
 {
 "classname" "worldspawn"
-"_tb_def" "builtin:Example.fgd"
+"_tb_def" "builtin:Qodot.fgd"
 // brush 0
 {
 ( 400 240 0 ) ( 400 241 0 ) ( 400 240 1 ) __TB_empty 0 0 0 1 1

--- a/addons/qodot/example_scenes/1-interactivity/0-point-entities/0-point-entities.map
+++ b/addons/qodot/example_scenes/1-interactivity/0-point-entities/0-point-entities.map
@@ -5,7 +5,7 @@
 "classname" "worldspawn"
 "mapversion" "220"
 "_tb_textures" "textures/base;textures/shaders;textures/special"
-"_tb_def" "builtin:Example.fgd"
+"_tb_def" "builtin:Qodot.fgd"
 // brush 0
 {
 ( -336 -64 -16 ) ( -336 -63 -16 ) ( -336 -64 -15 ) base/grid [ 0 -1 0 0 ] [ -0 -0 -1 0 ] 0 1 1

--- a/addons/qodot/example_scenes/1-interactivity/1-brush-entities/1-brush-entities.map
+++ b/addons/qodot/example_scenes/1-interactivity/1-brush-entities/1-brush-entities.map
@@ -5,7 +5,7 @@
 "classname" "worldspawn"
 "mapversion" "220"
 "_tb_textures" "textures/base;textures/shaders;textures/special"
-"_tb_def" "builtin:Example.fgd"
+"_tb_def" "builtin:Qodot.fgd"
 // brush 0
 {
 ( -224 -64 -16 ) ( -224 -63 -16 ) ( -224 -64 -15 ) base/grid [ 0 -1 0 0 ] [ -0 -0 -1 0 ] 0 1 1

--- a/addons/qodot/example_scenes/1-interactivity/2-worldspawn-layers/2-worldspawn-layers.map
+++ b/addons/qodot/example_scenes/1-interactivity/2-worldspawn-layers/2-worldspawn-layers.map
@@ -5,7 +5,7 @@
 "classname" "worldspawn"
 "mapversion" "220"
 "_tb_textures" "textures/base;textures/layers"
-"_tb_def" "builtin:Example.fgd"
+"_tb_def" "builtin:Qodot.fgd"
 // brush 0
 {
 ( -512 -224 -16 ) ( -512 -223 -16 ) ( -512 -224 -15 ) base/grid [ 0 -1 0 0 ] [ -0 -0 -1 0 ] 0 1 1

--- a/addons/qodot/example_scenes/1-interactivity/3-basic-signal-wiring/3-basic-signal-wiring.map
+++ b/addons/qodot/example_scenes/1-interactivity/3-basic-signal-wiring/3-basic-signal-wiring.map
@@ -5,7 +5,7 @@
 "classname" "worldspawn"
 "mapversion" "220"
 "_tb_textures" "textures/base;textures/layers"
-"_tb_def" "builtin:Example.fgd"
+"_tb_def" "builtin:Qodot.fgd"
 // brush 0
 {
 ( -192 -160 -16 ) ( -192 -159 -16 ) ( -192 -160 -15 ) base/grid [ 0 -1 0 0 ] [ -0 -0 -1 0 ] 0 0.125 0.125

--- a/addons/qodot/example_scenes/1-interactivity/4-advanced-signal-wiring/4-advanced-signal-wiring.map
+++ b/addons/qodot/example_scenes/1-interactivity/4-advanced-signal-wiring/4-advanced-signal-wiring.map
@@ -5,7 +5,7 @@
 "classname" "worldspawn"
 "mapversion" "220"
 "_tb_textures" "textures/base;textures/layers"
-"_tb_def" "builtin:Example.fgd"
+"_tb_def" "builtin:Qodot.fgd"
 // brush 0
 {
 ( -192 -160 -16 ) ( -192 -159 -16 ) ( -192 -160 -15 ) base/grid [ 0 -1 0 0 ] [ -0 -0 -1 0 ] 0 0.125 0.125

--- a/addons/qodot/example_scenes/2-miscallaneous/0-trenchbroom-group-hierarchy/0-trenchbroom-group-hierarchy.map
+++ b/addons/qodot/example_scenes/2-miscallaneous/0-trenchbroom-group-hierarchy/0-trenchbroom-group-hierarchy.map
@@ -5,7 +5,7 @@
 "classname" "worldspawn"
 "mapversion" "220"
 "_tb_textures" "textures/base;textures/orrery;textures/shaders;textures/special"
-"_tb_def" "builtin:Example.fgd"
+"_tb_def" "builtin:Qodot.fgd"
 // brush 0
 {
 ( -64 0 256 ) ( -59.712812921100124 -16 272.56441888656036 ) ( -61.819252882500166 -16.564418886561313 256 ) orrery/sun [ -0.0503174 -0.382199 -0.922709 223.833 ] [ 0.0208112 -0.92408 0.381632 6.10611 ] 0 1 1

--- a/addons/qodot/example_scenes/2-miscallaneous/1-runtime-map-building/1-runtime-map-building.map
+++ b/addons/qodot/example_scenes/2-miscallaneous/1-runtime-map-building/1-runtime-map-building.map
@@ -5,7 +5,7 @@
 "classname" "worldspawn"
 "mapversion" "220"
 "_tb_textures" "textures/base;textures/layers;textures/pbr;textures/shaders;textures/special"
-"_tb_def" "builtin:Example.fgd"
+"_tb_def" "builtin:Qodot.fgd"
 "message" "Qodot Test Map"
 // brush 0
 {


### PR DESCRIPTION
Fixes this error in opening a map in trenchbroom:
`Could not load builtin entity definition file 'Example.fgd': /usr/share/TrenchBroom/games/Qodot/Example.fgd`