### PR TITLE
Add multiple texture extension support to QodotMap node

### DIFF
--- a/addons/qodot/src/nodes/qodot_map.gd
+++ b/addons/qodot/src/nodes/qodot_map.gd
@@ -16,7 +16,7 @@ var map_file := "" setget set_map_file
 var inverse_scale_factor := 16.0
 var entity_fgd := preload("res://addons/qodot/game_definitions/fgd/qodot_fgd.tres")
 var base_texture_dir := "res://textures"
-var texture_file_extension := "png"
+var texture_file_extensions := PoolStringArray(["png"])
 
 var worldspawn_layers := [] setget set_worldspawn_layers
 
@@ -98,7 +98,7 @@ func _get_property_list() -> Array:
 		QodotUtil.property_dict('entity_fgd', TYPE_OBJECT, PROPERTY_HINT_RESOURCE_TYPE, 'Resource'),
 		QodotUtil.category_dict('Textures'),
 		QodotUtil.property_dict('base_texture_dir', TYPE_STRING, PROPERTY_HINT_DIR),
-		QodotUtil.property_dict('texture_file_extension', TYPE_STRING),
+		QodotUtil.property_dict('texture_file_extensions', TYPE_STRING_ARRAY),
 		QodotUtil.property_dict('worldspawn_layers', TYPE_ARRAY),
 		QodotUtil.property_dict('brush_clip_texture', TYPE_STRING),
 		QodotUtil.property_dict('face_skip_texture', TYPE_STRING),
@@ -340,7 +340,7 @@ func fetch_texture_list() -> Array:
 func init_texture_loader() -> QodotTextureLoader:
 	return QodotTextureLoader.new(
 		base_texture_dir,
-		texture_file_extension,
+		texture_file_extensions,
 		texture_wads
 	)
 

--- a/addons/qodot/src/util/qodot_texture_loader.gd
+++ b/addons/qodot/src/util/qodot_texture_loader.gd
@@ -48,7 +48,7 @@ const PBR_SUFFIX_PROPERTIES := {
 
 # Parameters
 var base_texture_path: String
-var texture_extension: String
+var texture_extensions: PoolStringArray
 var texture_wads: Array
 
 # Instances
@@ -69,11 +69,11 @@ func get_pbr_suffix_pattern(suffix: int) -> String:
 # Overrides
 func _init(
 		base_texture_path: String,
-		texture_extension: String,
+		texture_extensions: PoolStringArray,
 		texture_wads: Array
 	) -> void:
 	self.base_texture_path = base_texture_path
-	self.texture_extension = texture_extension
+	self.texture_extensions = texture_extensions
 
 	load_texture_wad_resources(texture_wads)
 
@@ -98,10 +98,10 @@ func load_texture(texture_name: String) -> Texture:
 		return null
 
 	# Load albedo texture if it exists
-	var texture_path := "%s/%s.%s" % [base_texture_path, texture_name, texture_extension]
-
-	if(directory.file_exists(texture_path)):
-		return load(texture_path) as Texture
+	for texture_extension in texture_extensions:
+		var texture_path := "%s/%s.%s" % [base_texture_path, texture_name, texture_extension]
+		if(directory.file_exists(texture_path)):
+			return load(texture_path) as Texture
 
 	var texture_name_lower : String = texture_name.to_lower()
 	for texture_wad in texture_wad_resources:
@@ -180,17 +180,18 @@ func get_pbr_texture(texture: String, suffix: int) -> Texture:
 
 	if texture_comps.size() == 0:
 		return null
-
-	var path := "%s/%s/%s" % [
-		base_texture_path,
-		texture_comps.join('/'),
-		get_pbr_suffix_pattern(suffix) % [
-			texture_comps[-1],
-			texture_extension
+	
+	for texture_extension in texture_extensions:
+		var path := "%s/%s/%s" % [
+			base_texture_path,
+			texture_comps.join('/'),
+			get_pbr_suffix_pattern(suffix) % [
+				texture_comps[-1],
+				texture_extension
+			]
 		]
-	]
 
-	if(directory.file_exists(path)):
-		return load(path) as Texture
+		if(directory.file_exists(path)):
+			return load(path) as Texture
 
 	return null


### PR DESCRIPTION
Majority of my textured materials are in jpg to save file size, but I would like to also use png materials for special cases such as transparency, therefore I require that QodotMap supports multiple file extension for textures.
![image](https://user-images.githubusercontent.com/1270094/115088162-e168ce00-9f0f-11eb-9c16-de4411477eae.png)
![Screenshot_20210416_234529](https://user-images.githubusercontent.com/1270094/115087964-86cf7200-9f0f-11eb-97f4-067f43ff8f5b.png)
